### PR TITLE
Set default log level to 'none'

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
             "alert",
             "emergency"
           ],
-          "default": "info",
+          "default": "none",
           "description": "Log level of LS server"
         }
       }


### PR DESCRIPTION
Along with these changes erlang-ls/erlang_ls#508 this makes logging opt-in when using the VS Code extension.