### PR TITLE
Include .escript in known file extensions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
           ".erl",
           ".hrl",
           ".src",
+          ".escript",
           ".config"
         ],
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
To match processing brought in to erlang_ls by https://github.com/erlang-ls/erlang_ls/pull/580