### PR TITLE
Update language configuration

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -10,11 +10,62 @@
   "autoClosingPairs": [
     [ "(", ")" ],
     [ "[", "]" ],
-    [ "{", "}" ]
+    [ "{", "}" ],
+    { "open": "'", "close": "'", "notIn": [ "string", "comment" ] },
+    { "open": "\"", "close": "\"", "notIn": [ "string" ] },
+    { "open": "<<\"", "close": "\">>", "notIn": [ "string" ] }
   ],
   "surroundingPairs": [
     [ "(", ")" ],
     [ "[", "]" ],
-    [ "{", "}" ]
+    [ "{", "}" ],
+    [ "'", "'" ],
+    [ "\"", "\"" ]
+  ],
+  "indentationRules": {
+    // Indent if a line ends brackets, "->" or most keywords. Also if prefixed
+    // with "||". This should work with most formatting models.
+    // The ((?!%).)* is to ensure this doesn't match inside comments.
+    "increaseIndentPattern": "^((?!%).)*([{([]|->|after|begin|case|catch|fun|if|of|try|when|(\\|\\|.*))$",
+    // Dedent after brackets, end or lone "->". The latter happens in a spec
+    // with indented types, typically after "when". Only do this if it's _only_
+    // preceded by whitespace.
+    "decreaseIndentPattern": "^\\s*([)}\\]]|end|->$)",
+    // Indent if after an incomplete map association operator, list
+    // comprehension and type specifier. But only once, then return to the
+    // previous indent.
+    "indentNextLinePattern": "^((?!%).)*(::|=>|:=|<-)$"
+  },
+  "onEnterRules": [
+    {
+      // Dedent after ";" or "."
+      "beforeText": "^((?!%).)*[;.]",
+      "action": {
+        "indent": "outdent"
+      }
+    },
+    // Inside a comment, pressing enter should insert comment markers (%) as
+    // appropriate. These three rules do just that.
+    {
+      "beforeText": "^\\s*%%%",
+      "action": {
+        "indent": "none",
+        "appendText": "%%% "
+      }
+    },
+    {
+      "beforeText": "^\\s*%%",
+      "action": {
+        "indent": "none",
+        "appendText": "%% "
+      }
+    },
+    {
+      "beforeText": "^\\s*%",
+      "action": {
+        "indent": "none",
+        "appendText": "% "
+      }
+    }
   ]
 }


### PR DESCRIPTION
This adds atoms, strings and binaries the pairs definitions, and adds indentation rules. These are not perfect, but the best you can do within the limitations of VS Code.

Especially `end` is hard, as it commonly should be dedented twice, which you can't specify using language-configuration.json. Even if you could, sometimes you shouldn't dedent twice, so it wouldn't be perfect either.

Still, this is a big improvement in ergonomics.
