### PR TITLE
[debugger] Fix els_dap override path

### DIFF
--- a/client/src/debugger.ts
+++ b/client/src/debugger.ts
@@ -24,7 +24,7 @@ class ErlangDebugAdapterExecutableFactory implements vscode.DebugAdapterDescript
         _executable: vscode.DebugAdapterExecutable | undefined,
     ): Promise<vscode.ProviderResult<vscode.DebugAdapterDescriptor>> {
         const erlangConfig = vscode.workspace;
-        const executable = erlangConfig.getConfiguration('erlang_ls').get<string>('dap_command') || '';
+        const executable = erlangConfig.getConfiguration('erlang_ls').get<string>('dapPath') || '';
 
         let command;
         let args;


### PR DESCRIPTION
In package.json, the path to override els_dap is "dapPath" not "dap_command"