### PR TITLE
Add some keywords+end pairs as brackets.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -5,7 +5,12 @@
   "brackets": [
     [ "(", ")" ],
     [ "[", "]" ],
-    [ "{", "}" ]
+    [ "{", "}" ],
+    [ "if", "end" ],
+    [ "case", "end" ],
+    [ "receive", "end" ],
+    [ "begin", "end" ],
+    [ "try", "end" ]
   ],
   "autoClosingPairs": [
     [ "(", ")" ],


### PR DESCRIPTION
With this change vscode shows a outline around keyword + end, so you can easier see what keyword the "end" belongs to. 