### PR TITLE
Allow space after structural elements in indentation

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,15 +26,15 @@
     // Indent if a line ends brackets, "->" or most keywords. Also if prefixed
     // with "||". This should work with most formatting models.
     // The ((?!%).)* is to ensure this doesn't match inside comments.
-    "increaseIndentPattern": "^((?!%).)*([{([]|->|after|begin|case|catch|fun|if|of|try|when|(\\|\\|.*))$",
+    "increaseIndentPattern": "^((?!%).)*([{([]|->|after|begin|case|catch|fun|if|of|try|when|(\\|\\|.*))\\s*$",
     // Dedent after brackets, end or lone "->". The latter happens in a spec
     // with indented types, typically after "when". Only do this if it's _only_
     // preceded by whitespace.
-    "decreaseIndentPattern": "^\\s*([)}\\]]|end|->$)",
+    "decreaseIndentPattern": "^\\s*([)}\\]]|end|->\\s*$)",
     // Indent if after an incomplete map association operator, list
     // comprehension and type specifier. But only once, then return to the
     // previous indent.
-    "indentNextLinePattern": "^((?!%).)*(::|=>|:=|<-)$"
+    "indentNextLinePattern": "^((?!%).)*(::|=>|:=|<-)\\s*$"
   },
   "onEnterRules": [
     {


### PR DESCRIPTION
This fixes a situation where indentation would be incorrect if you had
a space after, for example, `of`. Pressing Return after:

    case Expr of|

would correctly lead to:

    case Expr of
        |

However, doing it for:

    case Expr of |

would incorrectly lead to:

    case Expr of
    |