### PR TITLE
add a custom escript runner to support who use the Erlang OTP 20+ project

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -101,13 +101,18 @@ export async function get_client(context: ExtensionContext): Promise<LanguageCli
         serverArgs.push("--log-dir", logPath);
     }
 
+    let escriptCmd = workspace.getConfiguration('erlang_ls').escriptPath;
+    if (escriptCmd == "") {
+        escriptCmd = "escript";
+    }
+    
     let serverOptions: ServerOptions = {
-        command: 'escript',
+        command: escriptCmd,
         args: serverArgs,
         transport: TransportKind.stdio
     };
 
-    verifyExecutable(serverPath);
+    verifyExecutable(serverPath, escriptCmd);
 
     return new LanguageClient(
         'erlang_ls',
@@ -117,8 +122,8 @@ export async function get_client(context: ExtensionContext): Promise<LanguageCli
     );
 }
 
-export function verifyExecutable(serverPath: string) {
-    const res = spawnSync('escript', [serverPath, "--version"]);
+export function verifyExecutable(serverPath: string, escriptCmd:string) {
+    const res = spawnSync(escriptCmd, [serverPath, "--version"]);
     if (res.status !== 0) {
         window.showErrorMessage('Could not start Language Server. Error: ' + res.stdout);
     }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
           "default": "",
           "description": "Override the default path of the els_dap executable with a custom one."
         },
+        "erlang_ls.escriptPath": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "description": "Override the default path of the escript executable with a custom one."
+        },
         "erlang_ls.logPath": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
For historical reasons I use the OTP20.3 in my project, and it's the default runtime in my path. When I use the erlang_ls plugin, it report an error 
```
Could not start Language Server. Error: 
=ERROR REPORT==== 28-Sep-2022::21:20:04 ===
beam/beam_load.c(1863): Error loading module erlang_ls:
  This BEAM file was compiled for a later version of the run-time system than 20.
  To fix this, please recompile this module with an 20 compiler.
  (Use of opcode 164; this emulator supports only up to 159.)

escript: exception error: undefined function erlang_ls:main/1
  in function  escript:run/2 (escript.erl, line 759)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 (init.erl, line 1085)
  in call from init:do_boot/3 (init.erl, line 793)
```
My solution is specify a OTP22+ escript to launch erlang_ls server, and it work well now. 