### PR TITLE
Set the correct indentation when using the maybe expression.

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,11 +26,11 @@
     // Indent if a line ends brackets, "->" or most keywords. Also if prefixed
     // with "||". This should work with most formatting models.
     // The ((?!%).)* is to ensure this doesn't match inside comments.
-    "increaseIndentPattern": "^((?!%).)*([{([]|->|after|begin|case|catch|fun|if|of|try|when|(\\|\\|.*))\\s*$",
+    "increaseIndentPattern": "^((?!%).)*([{([]|->|after|begin|case|catch|fun|if|of|try|when|maybe|else|(\\|\\|.*))\\s*$",
     // Dedent after brackets, end or lone "->". The latter happens in a spec
     // with indented types, typically after "when". Only do this if it's _only_
     // preceded by whitespace.
-    "decreaseIndentPattern": "^\\s*([)}\\]]|end|->\\s*$)",
+    "decreaseIndentPattern": "^\\s*([)}\\]]|end|else|->\\s*$)",
     // Indent if after an incomplete map association operator, list
     // comprehension and type specifier. But only once, then return to the
     // previous indent.


### PR DESCRIPTION
This PR fixes the indentation rules when using the maybe expression introduced with Erlang/OTP 25.