### PR TITLE
Add custom escript runner configuration option

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -101,13 +101,18 @@ export async function get_client(context: ExtensionContext): Promise<LanguageCli
         serverArgs.push("--log-dir", logPath);
     }
 
+    let escriptPath = workspace.getConfiguration('erlang_ls').escriptPath;
+    if (escriptPath === "") {
+        escriptPath = 'escript';
+    }
+
     let serverOptions: ServerOptions = {
-        command: 'escript',
+        command: escriptPath,
         args: serverArgs,
         transport: TransportKind.stdio
     };
 
-    verifyExecutable(serverPath);
+    verifyExecutable(serverPath, escriptPath);
 
     return new LanguageClient(
         'erlang_ls',
@@ -117,8 +122,8 @@ export async function get_client(context: ExtensionContext): Promise<LanguageCli
     );
 }
 
-export function verifyExecutable(serverPath: string) {
-    const res = spawnSync('escript', [serverPath, "--version"]);
+export function verifyExecutable(serverPath: string, escriptPath: string) {
+    const res = spawnSync(escriptPath, [serverPath, "--version"]);
     if (res.status !== 0) {
         window.showErrorMessage('Could not start Language Server. Error: ' + res.stdout);
     }

--- a/client/src/debugger.ts
+++ b/client/src/debugger.ts
@@ -26,7 +26,7 @@ class ErlangDebugAdapterExecutableFactory implements vscode.DebugAdapterDescript
         const erlangConfig = vscode.workspace;
         const executable = erlangConfig.getConfiguration('erlang_ls').get<string>('dapPath') || '';
 
-        let command = 'escript';
+        const command = erlangConfig.getConfiguration('erlang_ls').get<string>('escriptPath') || 'escript';
         let args;
 
         if (executable.length > 0) {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
           "default": "",
           "description": "Override the default path of the els_dap executable with a custom one."
         },
+        "erlang_ls.escriptPath": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "description": "Override the default path of the escript executable with a custom one."
+        },
         "erlang_ls.logPath": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
Hi,

This is basically a copy and finish of #136.
Motivation for this change is to better support remote development in vscode.

Reasoning:
1. In erlang/otp repository there is .devcontainer configuration. However it is not usable in it's current form.
It is based on ubuntu image which installs otp 22 from ubuntu repositories, then it downloads 3 last versions of erlang from kerl.
However you cannot choose which one of those to use, since vscode cannot execute an additional command when entering the dev container. You can of course modify the container configuration, but each time you want to do that, you would need to rebuild the container.

2. Internally in other projects some of the people use remote ssh to develop erlang code. However the environment is not configured to work with remote ssh development. Upon opening the repository, we must run initialization script that adds correct erlang to path.
However vscode cannot do that, it must have this erlang set somehow. Workaround is to set this erlang path in .bashrc file, but this has the problem that it is a global change, but we would like to have this settable per workspace.
This pull request would achieve it.